### PR TITLE
Update LUUtils.ps1

### DIFF
--- a/build/yaml/templates/LUUtils.ps1
+++ b/build/yaml/templates/LUUtils.ps1
@@ -25,7 +25,7 @@ function Get-LUModels
     $luModels = @()
     foreach($luModel in $crossTrainedLUModels) {
         # Load the dialog JSON and find the recognizer kind
-        $luDialog = $luRecognizerDialogs | Where-Object { $_ -match "/$luModel.dialog" }
+        $luDialog = $luRecognizerDialogs | Where-Object { $_ -match "$luModel.dialog" }
         $dialog = Get-Content -Path "$sourceDirectory/$luDialog" | ConvertFrom-Json
         $recognizerKind = ($dialog | Select -ExpandProperty "`$kind")
 

--- a/build/yaml/templates/LUUtils.ps1
+++ b/build/yaml/templates/LUUtils.ps1
@@ -25,7 +25,7 @@ function Get-LUModels
     $luModels = @()
     foreach($luModel in $crossTrainedLUModels) {
         # Load the dialog JSON and find the recognizer kind
-        $luDialog = $luRecognizerDialogs | Where-Object { $_ -match "$luModel.dialog" }
+        $luDialog = $luRecognizerDialogs | Where-Object { $_ -match "/$luModel.dialog" }
         $dialog = Get-Content -Path "$sourceDirectory/$luDialog" | ConvertFrom-Json
         $recognizerKind = ($dialog | Select -ExpandProperty "`$kind")
 


### PR DESCRIPTION
This will avoid the error _"**Cannot find path**
'/home/vsts/work/1/s/dialogs/NewLicense/recognizers/NewLicense.en-us.lu.dialog dialogs/RenewLicense/recognizers/RenewLicense.en-us.lu.dialog' **because it does not exist**"_ from occurring due to the recognizers having names as substrings of another recognizer. 
The "/" in front of the luModel name will help to avoid taking the recognizers with substring names such as "renewLicense" which has newLicense in it. 
In the current scenario, both the recognizers are returned which will throw an error while running the pipeline as the path could not be found as there will be two recognizer paths in the same line.