### PR TITLE
Composer CICD pipeline tweaks

### DIFF
--- a/build/yaml/buildAndDeploy.yaml
+++ b/build/yaml/buildAndDeploy.yaml
@@ -13,8 +13,8 @@ trigger:
 pool:
   vmImage: ubuntu-latest
 
-# These parameters map Azure DevOps pipeline variables to paramaters 
-# that are used in # the different pipeline tasks.
+# Parameters with defaults formatted as $(name) get their values 
+# from variables of that name defined in the Azure DevOps pipeline UI. 
 parameters:
 - name: azureServiceConnection
   displayName: Azure service connection
@@ -57,23 +57,7 @@ parameters:
   default: $(BOTPROJECTNAME) 
 
 # LUIS Parameters
-# General
-- name: luisAppId
-  displayName: LUIS app ID
-  type: string
-  default: $(LUISAPPID)
-  
 # LUIS Authoring (used to build, train and publish LUIS models)
-- name: luisAuthoringRegion
-  displayName: LUIS authoring region
-  type: string
-  default: "westus"
-
-- name: luisAuthoringEndpoint
-  displayName: LUIS authoring endpoint
-  type: string
-  default: "https://westus.api.cognitive.microsoft.com"
-
 - name: luisAuthoringKey
   displayName: LUIS authoring key
   type: string
@@ -83,7 +67,7 @@ parameters:
 - name: luisEndpoint
   displayName: LUIS endpoint
   type: string
-  default: "https://westus.api.cognitive.microsoft.com"
+  default: $(LUISENDPOINT)
 
 - name: luisEndpointKey
   displayName: LUIS endpoint key
@@ -117,6 +101,7 @@ parameters:
   default: "westus"
 
 steps:
+
 # Install prerequisites
 - template: templates/installPrerequisites.yaml
 
@@ -126,7 +111,6 @@ steps:
     sourceDirectory: "$(System.DefaultWorkingDirectory)/${{ parameters.botProjectDirectory }}"
     botName: "${{ parameters.botName }}"
     luisAuthoringKey: "${{ parameters.luisAuthoringKey }}"
-    luisAuthoringRegion: "${{ parameters.luisAuthoringRegion }}"
     qnaSubscriptionKey: "${{ parameters.qnaSubscriptionKey }}"
 
 # Deploy and configure web app

--- a/build/yaml/templates/buildAndDeployDotNetWebApp.yaml
+++ b/build/yaml/templates/buildAndDeployDotNetWebApp.yaml
@@ -88,7 +88,7 @@ steps:
     azureSubscription: ${{ parameters.azureServiceConnection }}
     appName: "${{ parameters.webAppName }}"
     resourceGroupName: "${{ parameters.resourceGroupName }}"
-    package: "$(System.DefaultWorkingDirectory)/output/zipDeploy/${{ parameters.webAppName }}.zip"
+    package: "$(System.DefaultWorkingDirectory)/output/zipDeploy/*.zip"
     deploymentMethod: zipDeploy
 
 # Configure web appSettings

--- a/build/yaml/templates/buildAndDeployModels.yaml
+++ b/build/yaml/templates/buildAndDeployModels.yaml
@@ -17,16 +17,11 @@ parameters:
   displayName: LUIS authoring key
   type: string
 
-- name: luisAuthoringRegion
-  displayName: LUIS authoring region
-  type: string
-
 - name: qnaSubscriptionKey
   displayName: QnA Maker subscription key
   type: string
 
 steps:
-
 # Prepare working folders
 - task: PowerShell@2
   displayName: "Prepare working folders"
@@ -60,7 +55,7 @@ steps:
       cd $outputDirectory
       ls -R
 
-# Publish LUIS models
+# Publish LUIS models if luisAuthoringKey is defined
 - task: PowerShell@2
   displayName: "Publish LUIS"
   inputs:
@@ -70,8 +65,9 @@ steps:
     # Note: the working directory needs to be set to the bot's source directory
     # to allow for the creation of relative paths in the generated config files.
     workingDirectory: ${{ parameters.sourceDirectory }}
+  condition: and(succeeded(), ne(variables['luisAuthoringKey'], ''))
 
-# Publish QnA Maker KBs
+# Publish QnA Maker KBs if qnaSubscriptionKey is defined
 - task: PowerShell@2
   displayName: "Publish QnA"
   inputs:
@@ -82,6 +78,7 @@ steps:
       
       # Build, train and publish the QnA maker models
       bf qnamaker:build --out $outputDirectory --in $sourceDirectory --subscriptionKey ${{ parameters.qnaSubscriptionKey }} --botName ${{ parameters.botName }} --suffix composer --force --log
+  condition: and(succeeded(), ne(variables['qnaSubscriptionKey'], ''))
 
 # Publish Orchestrator models
 - task: PowerShell@2


### PR DESCRIPTION
## Description
Pipeline fixes and tweaks.

## Details
- Removed 3 parameters that are never used.
- Let luisEndpoint URL be set from an ADO variable: Composer allows selecting any of 3 regions. This change supports cases where regions other than "West US" have been selected. It also supports endpoints generated from the LUIS portal and imported into Composer. Those URL names are not related to region.
- Change Zip file reference from "${{ parameters.webAppName }}.zip" to "\*.zip": The generated .zip file name actually matches the project name, not the web app name. There was no var carrying the project name, so I opted for "\*". This works because there is only 1 zip file found in the zipDeploy folder.
- Conditionals added for running LUIS and Q&A publishing tasks: This prevents the pipeline from breaking when the bot has no Q&A or no LUIS component.

## Tests
Test pipelines can be found here:
https://fuselabs.visualstudio.com/SDK_v4/_build/index?definitionId=1463
https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=297624