### PR TITLE
Composer CICD pipeline tweaks plus

### DIFF
--- a/BasicAssistant/BasicAssistant/Nuget.config
+++ b/BasicAssistant/BasicAssistant/Nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/build/yaml/buildAndDeploy.yaml
+++ b/build/yaml/buildAndDeploy.yaml
@@ -13,8 +13,8 @@ trigger:
 pool:
   vmImage: ubuntu-latest
 
-# These parameters map Azure DevOps pipeline variables to paramaters 
-# that are used in # the different pipeline tasks.
+# Parameters with defaults formatted as $(name) get their values 
+# from variables of that name defined in the Azure DevOps pipeline UI. 
 parameters:
 - name: azureServiceConnection
   displayName: Azure service connection
@@ -57,23 +57,7 @@ parameters:
   default: $(BOTPROJECTNAME) 
 
 # LUIS Parameters
-# General
-- name: luisAppId
-  displayName: LUIS app ID
-  type: string
-  default: $(LUISAPPID)
-  
 # LUIS Authoring (used to build, train and publish LUIS models)
-- name: luisAuthoringRegion
-  displayName: LUIS authoring region
-  type: string
-  default: "westus"
-
-- name: luisAuthoringEndpoint
-  displayName: LUIS authoring endpoint
-  type: string
-  default: "https://westus.api.cognitive.microsoft.com"
-
 - name: luisAuthoringKey
   displayName: LUIS authoring key
   type: string
@@ -83,7 +67,7 @@ parameters:
 - name: luisEndpoint
   displayName: LUIS endpoint
   type: string
-  default: "https://westus.api.cognitive.microsoft.com"
+  default: $(LUISENDPOINT)
 
 - name: luisEndpointKey
   displayName: LUIS endpoint key
@@ -117,6 +101,7 @@ parameters:
   default: "westus"
 
 steps:
+
 # Install prerequisites
 - template: templates/installPrerequisites.yaml
 
@@ -126,7 +111,6 @@ steps:
     sourceDirectory: "$(System.DefaultWorkingDirectory)/${{ parameters.botProjectDirectory }}"
     botName: "${{ parameters.botName }}"
     luisAuthoringKey: "${{ parameters.luisAuthoringKey }}"
-    luisAuthoringRegion: "${{ parameters.luisAuthoringRegion }}"
     qnaSubscriptionKey: "${{ parameters.qnaSubscriptionKey }}"
 
 # Deploy and configure web app

--- a/build/yaml/buildAndDeploy.yaml
+++ b/build/yaml/buildAndDeploy.yaml
@@ -63,6 +63,11 @@ parameters:
   type: string
   default: $(LUISAUTHORINGKEY)
 
+- name: luisAuthoringRegion
+  displayName: LUIS authoring region
+  type: string
+  default: $(LUISAUTHORINGREGION)
+  
 # LUIS Runtime (used to access LUIS while the bot is running)
 - name: luisEndpoint
   displayName: LUIS endpoint
@@ -111,6 +116,7 @@ steps:
     sourceDirectory: "$(System.DefaultWorkingDirectory)/${{ parameters.botProjectDirectory }}"
     botName: "${{ parameters.botName }}"
     luisAuthoringKey: "${{ parameters.luisAuthoringKey }}"
+    luisAuthoringRegion: "${{ parameters.luisAuthoringRegion }}"
     qnaSubscriptionKey: "${{ parameters.qnaSubscriptionKey }}"
 
 # Deploy and configure web app

--- a/build/yaml/templates/Build-LUIS.ps1
+++ b/build/yaml/templates/Build-LUIS.ps1
@@ -11,6 +11,7 @@ Param(
 	[string] $sourceDirectory,
 	[string] $crossTrainedLUDirectory,
 	[string] $authoringKey,
+	[string] $authoringRegion,
 	[string] $botName
 )
 
@@ -20,12 +21,13 @@ Param(
 if ($PSBoundParameters.Keys.Count -lt 5) {
     Write-Host "Builds, trains and publishes LUIS models" 
     Write-Host "Usage:"
-    Write-Host "`t Build-LUIS.ps1 -outputDirectory ./generated -sourceDirectory ./ -crossTrainedLUDirectory ./generated/interruption -authoringKey 12345612345 -botName MyBotName"  
+    Write-Host "`t Build-LUIS.ps1 -outputDirectory ./generated -sourceDirectory ./ -crossTrainedLUDirectory ./generated/interruption -authoringKey 12345612345 -authoringRegion westus -botName MyBotName"  
     Write-Host "Parameters: "
     Write-Host "`t  outputDirectory - Directory for processed config file"
     Write-Host "`t  sourceDirectory - Directory containing bot's source code."
     Write-Host "`t  crossTrainedLUDirectory - Directory containing .lu/.qna files to process."
     Write-Host "`t  authoringKey - LUIS Authoring key."
+    Write-Host "`t  authoringRegion - LUIS Authoring region."
     Write-Host "`t  botName - Bot's name."
     exit 1
 }
@@ -47,4 +49,4 @@ New-LuConfigFile -luConfig $luConfigFile -luModels $models -path "."
 Get-Content $luConfigFile
 
 # Publish and tain LUIS models
-bf luis:build --out $outputDirectory --authoringKey $authoringKey --botName $botName --suffix composer --force --log --luConfig $luConfigFile
+bf luis:build --out $outputDirectory --authoringKey $authoringKey --region $authoringRegion --botName $botName --suffix composer --force --log --luConfig $luConfigFile

--- a/build/yaml/templates/Build-LUIS.ps1
+++ b/build/yaml/templates/Build-LUIS.ps1
@@ -27,7 +27,7 @@ if ($PSBoundParameters.Keys.Count -lt 5) {
     Write-Host "`t  sourceDirectory - Directory containing bot's source code."
     Write-Host "`t  crossTrainedLUDirectory - Directory containing .lu/.qna files to process."
     Write-Host "`t  authoringKey - LUIS Authoring key."
-    Write-Host "`t  authoringRegion - LUIS Authoring region."
+    Write-Host "`t  authoringRegion - LUIS Authoring region. [westus|westeurope|australiaeast]"
     Write-Host "`t  botName - Bot's name."
     exit 1
 }

--- a/build/yaml/templates/buildAndDeployDotNetWebApp.yaml
+++ b/build/yaml/templates/buildAndDeployDotNetWebApp.yaml
@@ -88,7 +88,7 @@ steps:
     azureSubscription: ${{ parameters.azureServiceConnection }}
     appName: "${{ parameters.webAppName }}"
     resourceGroupName: "${{ parameters.resourceGroupName }}"
-    package: "$(System.DefaultWorkingDirectory)/output/zipDeploy/${{ parameters.webAppName }}.zip"
+    package: "$(System.DefaultWorkingDirectory)/output/zipDeploy/*.zip"
     deploymentMethod: zipDeploy
 
 # Configure web appSettings

--- a/build/yaml/templates/buildAndDeployModels.yaml
+++ b/build/yaml/templates/buildAndDeployModels.yaml
@@ -17,16 +17,11 @@ parameters:
   displayName: LUIS authoring key
   type: string
 
-- name: luisAuthoringRegion
-  displayName: LUIS authoring region
-  type: string
-
 - name: qnaSubscriptionKey
   displayName: QnA Maker subscription key
   type: string
 
 steps:
-
 # Prepare working folders
 - task: PowerShell@2
   displayName: "Prepare working folders"
@@ -60,7 +55,7 @@ steps:
       cd $outputDirectory
       ls -R
 
-# Publish LUIS models
+# Publish LUIS models if luisAuthoringKey is defined
 - task: PowerShell@2
   displayName: "Publish LUIS"
   inputs:
@@ -70,8 +65,9 @@ steps:
     # Note: the working directory needs to be set to the bot's source directory
     # to allow for the creation of relative paths in the generated config files.
     workingDirectory: ${{ parameters.sourceDirectory }}
+  condition: and(succeeded(), ne(variables['luisAuthoringKey'], ''))
 
-# Publish QnA Maker KBs
+# Publish QnA Maker KBs if qnaSubscriptionKey is defined
 - task: PowerShell@2
   displayName: "Publish QnA"
   inputs:
@@ -82,6 +78,7 @@ steps:
       
       # Build, train and publish the QnA maker models
       bf qnamaker:build --out $outputDirectory --in $sourceDirectory --subscriptionKey ${{ parameters.qnaSubscriptionKey }} --botName ${{ parameters.botName }} --suffix composer --force --log
+  condition: and(succeeded(), ne(variables['qnaSubscriptionKey'], ''))
 
 # Publish Orchestrator models
 - task: PowerShell@2

--- a/build/yaml/templates/buildAndDeployModels.yaml
+++ b/build/yaml/templates/buildAndDeployModels.yaml
@@ -17,6 +17,10 @@ parameters:
   displayName: LUIS authoring key
   type: string
 
+- name: luisAuthoringRegion
+  displayName: LUIS authoring region
+  type: string
+
 - name: qnaSubscriptionKey
   displayName: QnA Maker subscription key
   type: string
@@ -61,7 +65,7 @@ steps:
   inputs:
     targetType: "filePath"
     filePath: "$(System.DefaultWorkingDirectory)/build/yaml/templates/Build-LUIS.ps1"
-    arguments: -outputDirectory ./generated -sourceDirectory ./ -crossTrainedLUDirectory ./generated/interruption -authoringKey ${{ parameters.luisAuthoringKey }} -botName ${{ parameters.botName }} 
+    arguments: -outputDirectory ./generated -sourceDirectory ./ -crossTrainedLUDirectory ./generated/interruption -authoringKey ${{ parameters.luisAuthoringKey }} -authoringRegion ${{ parameters.luisAuthoringRegion }} -botName ${{ parameters.botName }} 
     # Note: the working directory needs to be set to the bot's source directory
     # to allow for the creation of relative paths in the generated config files.
     workingDirectory: ${{ parameters.sourceDirectory }}


### PR DESCRIPTION
This PR is identical to and supersedes PR #8 with one additional change:

The file BasicAssistant/BasicAssistant/Nuget.config has been deleted to fix the build check error:

`
NuGet Security Analysis found 1 package manifests with myget feed declared. MyGet feeds are not allowed by Microsoft policy.
`
## Details (same as #8)
- Removed 3 parameters that are never used.
- Let luisEndpoint URL be set from an ADO variable: Composer allows selecting any of 3 regions. This change supports cases where regions other than "West US" have been selected. It also supports endpoints generated from the LUIS portal and imported into Composer. Those URL names are not related to region.
- Change Zip file reference from "${{ parameters.webAppName }}.zip" to "\*.zip": The generated .zip file name actually matches the project name, not the web app name. There was no var carrying the project name, so I opted for "\*". This works because there is only 1 zip file found in the zipDeploy folder.
- Conditionals added for running LUIS and Q&A publishing tasks: This prevents the pipeline from breaking when the bot has no Q&A or no LUIS component.

## Tests
Test pipelines can be found here:
https://fuselabs.visualstudio.com/SDK_v4/_build/index?definitionId=1463
https://dev.azure.com/FuseLabs/SDK_v4/_build/results?buildId=297624